### PR TITLE
Remove use of deprecated loaOf type

### DIFF
--- a/modules/monitoring-services.nix
+++ b/modules/monitoring-services.nix
@@ -191,7 +191,7 @@ in {
       };
 
       monitoredNodes = mkOption {
-        type = types.loaOf (types.submodule monitoredNodeOptions);
+        type = types.attrsOf (types.submodule monitoredNodeOptions);
         default = { };
         description = ''
           Attribute set of Nodes to be monitored.


### PR DESCRIPTION
🚨 this shit's a breaking change y'all 🚨

apparently `loaOf` triggers a deprecation warning in current `nixpkgs-unstable`
which advises switching to `attrsOf`. So I did. But this has to be reflected on
the consumer side. I had to go from this:

``` nix
      monitoredNodes = lib.mapAttrsToList
      (nodeName: node: {
        name = nodeName;
        hasNginx = node.config.services.nginx.enable;
       }) nodes;
```

to that:
``` nix
      monitoredNodes = lib.mapAttrs
      (_: { config, ... }: {
        hasNginx = config.services.nginx.enable;
       }) nodes;
```

pretty straight-forward but breaking nonetheless. I'm working against this
branch because that warning makes my eyes bleed.