### PR TITLE
Fix sentry module

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -15,7 +15,9 @@ let
     else iohkNix.nixpkgs;
 
   overlays = (import ../overlays sourcePaths) ++
-    [ (import ../globals-deployers.nix) ];
+    [ (import ../globals-deployers.nix)
+      (import sourcePaths.nixpkgs-mozilla)
+    ];
 
   pkgs = import nixpkgs {
     inherit config system crossSystem overlays;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -70,5 +70,17 @@
         "type": "tarball",
         "url": "https://github.com/input-output-hk/nixops-packet/archive/b96a78c57d315bb292318f7fb4f198b1483e188b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "nixpkgs-mozilla": {
+        "branch": "master",
+        "description": "mozilla related nixpkgs (extends nixos/nixpkgs repo)",
+        "homepage": null,
+        "owner": "mozilla",
+        "repo": "nixpkgs-mozilla",
+        "rev": "e912ed483e980dfb4666ae0ed17845c4220e5e7c",
+        "sha256": "08fvzb8w80bkkabc1iyhzd15f4sm7ra10jn32kfch5klgl0gj3j3",
+        "type": "tarball",
+        "url": "https://github.com/mozilla/nixpkgs-mozilla/archive/e912ed483e980dfb4666ae0ed17845c4220e5e7c.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/overlays/overlay-list.nix
+++ b/overlays/overlay-list.nix
@@ -3,4 +3,5 @@
   ./niv.nix
   ./nixops.nix
   ./nginx-monitoring.nix
+  ./rust.nix
 ]

--- a/overlays/packages.nix
+++ b/overlays/packages.nix
@@ -14,8 +14,8 @@ in
     };
   };
 
-  sentry       = callPackage ../pkgs/sentry { };
+  sentry       = import ../pkgs/sentry { pkgs = self; };
   symbolicator = callPackage ../pkgs/symbolicator { };
-  snuba        = callPackage ../pkgs/snuba { python = self.python37; };
+  snuba        = import ../pkgs/snuba { pkgs = self; };
   naersk       = callPackage self.sourcePaths.naersk {};
 }

--- a/overlays/rust.nix
+++ b/overlays/rust.nix
@@ -1,0 +1,12 @@
+self: super:
+let
+  rustChannel = self.rustChannelOf { date = "2020-02-04"; channel = "nightly"; };
+in
+rec {
+  rustc = rustChannel.rust;
+  cargo = rustChannel.cargo;
+  rustPlatform = super.recurseIntoAttrs (super.rust.makeRustPlatform {
+    rustc = rustChannel.rust;
+    cargo = rustChannel.cargo;
+  });
+}

--- a/pkgs/sentry/requirements.nix
+++ b/pkgs/sentry/requirements.nix
@@ -489,17 +489,19 @@ let
     };
 
     "django" = python.mkDerivation {
-      name = "django-1.9.13";
+      name = "django-1.11.29";
       src = pkgs.fetchurl {
-        url = "https://files.pythonhosted.org/packages/6c/bf/4ac9eaa04581797a68649828b88a147f641d745e0c7b3696db5c6caedc41/Django-1.9.13.tar.gz";
-        sha256 = "c007dba5086061f7d0f4d88a3bc4016d881a7eede86d6c1c4fdbbaadddd53f1d";
+        url = "https://files.pythonhosted.org/packages/68/ab/2278a4a9404fac661be1be9627f11336613149e07fc4df0b6e929cc9f300/Django-1.11.29.tar.gz";
+        sha256 = "4200aefb6678019a0acf0005cd14cfce3a5e6b9b90d06145fcdd2e474ad4329c";
 };
       doCheck = commonDoCheck;
       format = "setuptools";
       buildInputs = commonBuildInputs ++ [ ];
-      propagatedBuildInputs = [ ];
+      propagatedBuildInputs = [
+        self."pytz"
+      ];
       meta = with pkgs.stdenv.lib; {
-        homepage = "http://www.djangoproject.com/";
+        homepage = "https://www.djangoproject.com/";
         license = licenses.bsdOriginal;
         description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design.";
       };
@@ -557,17 +559,17 @@ let
     };
 
     "djangorestframework" = python.mkDerivation {
-      name = "djangorestframework-3.4.7";
+      name = "djangorestframework-3.9.4";
       src = pkgs.fetchurl {
-        url = "https://files.pythonhosted.org/packages/bf/fb/40a6bb1259e295cfe9379715f648a3243171ce45c8b349c979f2e57c4fbe/djangorestframework-3.4.7.tar.gz";
-        sha256 = "34f588119a6de012a0cbe3836c31a2d5f620993c3b955f64c951a3072e617e47";
+        url = "https://files.pythonhosted.org/packages/ce/1d/877af49d161879bc26585696ca0cab6487c4cb7604263cf5f1c745f5141a/djangorestframework-3.9.4.tar.gz";
+        sha256 = "c12869cfd83c33d579b17b3cb28a2ae7322a53c3ce85580c2a2ebe4e3f56c4fb";
 };
       doCheck = commonDoCheck;
       format = "setuptools";
       buildInputs = commonBuildInputs ++ [ ];
       propagatedBuildInputs = [ ];
       meta = with pkgs.stdenv.lib; {
-        homepage = "http://www.django-rest-framework.org";
+        homepage = "https://www.django-rest-framework.org/";
         license = licenses.bsdOriginal;
         description = "Web APIs for Django, made easy.";
       };
@@ -644,8 +646,8 @@ let
     "functools32" = python.mkDerivation {
       name = "functools32-3.2.3.post2";
       src = pkgs.fetchurl {
-        url = "https://files.pythonhosted.org/packages/c5/60/6ac26ad05857c601308d8fb9e87fa36d0ebf889423f47c3502ef034365db/functools32-3.2.3-2.tar.gz";
-        sha256 = "f6253dfbe0538ad2e387bd8fdfd9293c925d63553f5813c4e587745416501e6d";
+        url = "https://files.pythonhosted.org/packages/5e/1a/0aa2c8195a204a9f51284018562dea77e25511f02fe924fac202fc012172/functools32-3.2.3-2.zip";
+        sha256 = "89d824aa6c358c421a234d7f9ee0bd75933a67c29588ce50aaa3acdf4d403fa0";
 };
       doCheck = commonDoCheck;
       format = "setuptools";
@@ -863,10 +865,10 @@ let
     };
 
     "grpcio" = python.mkDerivation {
-      name = "grpcio-1.29.0";
+      name = "grpcio-1.30.0";
       src = pkgs.fetchurl {
-        url = "https://files.pythonhosted.org/packages/f1/23/62d3e82fa4c505f3195315c8a774b2e656b556d174329aa98edb829e48bc/grpcio-1.29.0.tar.gz";
-        sha256 = "a97ea91e31863c9a3879684b5fb3c6ab4b17c5431787548fc9f52b9483ea9c25";
+        url = "https://files.pythonhosted.org/packages/5e/29/1bd649737e427a6bb850174293b4f2b72ab80dd49462142db9b81e1e5c7b/grpcio-1.30.0.tar.gz";
+        sha256 = "e8f2f5d16e0164c415f1b31a8d9a81f2e4645a43d1b261375d6bab7b0adf511f";
 };
       doCheck = commonDoCheck;
       format = "setuptools";
@@ -1619,17 +1621,17 @@ let
     };
 
     "pyyaml" = python.mkDerivation {
-      name = "pyyaml-3.11";
+      name = "pyyaml-5.3.1";
       src = pkgs.fetchurl {
-        url = "https://files.pythonhosted.org/packages/75/5e/b84feba55e20f8da46ead76f14a3943c8cb722d40360702b2365b91dec00/PyYAML-3.11.tar.gz";
-        sha256 = "c36c938a872e5ff494938b33b14aaa156cb439ec67548fcab3535bb78b0846e8";
+        url = "https://files.pythonhosted.org/packages/64/c2/b80047c7ac2478f9501676c988a5411ed5572f35d1beff9cae07d321512c/PyYAML-5.3.1.tar.gz";
+        sha256 = "b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d";
 };
       doCheck = commonDoCheck;
       format = "setuptools";
       buildInputs = commonBuildInputs ++ [ ];
       propagatedBuildInputs = [ ];
       meta = with pkgs.stdenv.lib; {
-        homepage = "http://pyyaml.org/wiki/PyYAML";
+        homepage = "https://github.com/yaml/pyyaml";
         license = licenses.mit;
         description = "YAML parser and emitter for Python";
       };

--- a/pkgs/sentry/requirements_frozen.txt
+++ b/pkgs/sentry/requirements_frozen.txt
@@ -23,11 +23,11 @@ cssutils==1.0.2
 datadog==0.30.0
 decorator==4.4.2
 defusedxml==0.6.0
-Django==1.9.13
+Django==1.11.29
 django-crispy-forms==1.6.1
 django-picklefield==1.0.0
 django-sudo==3.1.0
-djangorestframework==3.4.7
+djangorestframework==3.9.4
 docutils==0.16
 email-reply-parser==0.2.0
 enum34==1.1.10
@@ -43,7 +43,7 @@ google-cloud-storage==1.13.3
 google-resumable-media==0.4.1
 googleapis-common-protos==1.6.0
 grpc-google-iam-v1==0.11.4
-grpcio==1.29.0
+grpcio==1.30.0
 hiredis==0.1.6
 httplib2==0.18.1
 idna==2.7
@@ -86,7 +86,7 @@ python-memcached==1.59
 python-u2flib-server==5.0.0
 python-utils==2.4.0
 pytz==2020.1
-PyYAML==3.11
+PyYAML==5.3.1
 qrcode==5.3
 querystring-parser==1.2.4
 rb==1.7


### PR DESCRIPTION
Fixes up a couple of issues with my previous PR:
  - Updates versions of django, djangorestframework, and pyyaml to fix dependency vulnerabilities Dependabot reported (https://github.com/input-output-hk/ops-lib/pull/34 https://github.com/input-output-hk/ops-lib/pull/33 https://github.com/input-output-hk/ops-lib/pull/32) 
  - Updates the rust compiler from 1.41 to 1.42 to fix the symbolicator build (symbolicator is used by Sentry).