### PR TITLE
Add Grafana extra data sources option

### DIFF
--- a/modules/monitoring-services.nix
+++ b/modules/monitoring-services.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, ... }:
+{ config, options, pkgs, lib, ... }:
 
 with lib;
 
@@ -150,7 +150,7 @@ in {
       };
 
       applicationDataSources = mkOption {
-        type = types.listOf types.attrs;
+        type = options.services.grafana.provision.datasources.type;
         default = [ ];
         description = ''
           Application specific grafana data sources.

--- a/modules/monitoring-services.nix
+++ b/modules/monitoring-services.nix
@@ -149,6 +149,28 @@ in {
         '';
       };
 
+      applicationDataSources = mkOption {
+        type = types.listOf types.attrs;
+        default = [ ];
+        description = ''
+          Application specific grafana data sources.
+          See "services.grafana.provision.datasources" for type
+          description.
+        '';
+        example = [{
+          name     = "postgres-tsdb";
+          type     = "postgres";
+          database = "testdb";
+          user     = "testuser";
+          editable = false;
+          access   = "direct";
+          url      = "localhost:5432";
+          jsonData = {
+            sslmode = "disable";
+          };
+        }];
+      };
+
       grafanaCreds = mkOption {
         type = types.attrs;
         description = ''
@@ -533,7 +555,7 @@ in {
               type = "prometheus";
               name = "prometheus";
               url = "http://localhost:9090/prometheus";
-            }];
+            }] ++ cfg.applicationDataSources;
             dashboards = [{
               name = "generic";
               options.path = ./grafana/generic;


### PR DESCRIPTION
- Add an option to the monitoring services module that allows the user
  to specify extra Grafana data sources. This is motivated by
  PM-2290 (https://jira.iohk.io/browse/PM-2290) which requires a
  postgres database data source.