### PR TITLE
Use chrony to sync time.

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -55,7 +55,12 @@ in {
         '';
       };
 
-      ntp.enable = true;
+      chrony = {
+        enable = true;
+        extraConfig = ''
+          allow 127/8
+        '';
+      };
       cron.enable = true;
     };
 

--- a/modules/monitoring-services.nix
+++ b/modules/monitoring-services.nix
@@ -796,7 +796,8 @@ in {
                     {
                       alert = "node_time_unsync";
                       expr =
-                        "abs(node_timex_offset_seconds) > 0.500 or node_timex_sync_status != 1";
+                        "abs(node_timex_offset_seconds) > 0.500 or
+                          (min_over_time(node_timex_sync_status[2m]) == 0 and node_timex_maxerror_seconds >= 16)";
                       for = "5m";
                       labels = { severity = "page"; };
                       annotations = {


### PR DESCRIPTION
 for some reason ntpd is freezing on nixos-20.09 on aws.
 Maybe related to aws timeserver. [They do document to use chrony](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html).