### PR TITLE
Use systemd timesyncd instead of ntpd

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -55,7 +55,7 @@ in {
         '';
       };
 
-      ntp.enable = true;
+      timesyncd.enable = true;
       cron.enable = true;
     };
 

--- a/modules/monitoring-exporters.nix
+++ b/modules/monitoring-exporters.nix
@@ -191,7 +191,6 @@ in {
             "netstat"
             "stat"
             "time"
-            "ntp"
             "timex"
             "vmstat"
             "logind"


### PR DESCRIPTION
timesyncd does not come with a sntp server so the `ntp` prometheus collector is removed.
But our alerting is based on the `timex` collector metrics so that's fine.