### PR TITLE
common: Don't override TERM.

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -35,8 +35,6 @@ in {
       ripgrep
     ] ++ (lib.optional config.local.commonGivesVim vim);
 
-    environment.variables.TERM = "xterm-256color";
-
     users.mutableUsers = false;
     users.users.root.openssh.authorizedKeys.keys = devOpsKeys;
 


### PR DESCRIPTION
Terminal emulators (including ssh) should set TERM
themselves. Overriding it here breaks terminals which aren't
xterm-256color. In particular, this causes two issues:

1. Broken NixOS prompts in ansi-term (TERM=eterm-color)
2. Broken remote editing with TRAMP in emacs (TERM=dumb)